### PR TITLE
Add log macros and logging setter funcs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0)
 find_path(ICE9_API_INCLUDE_DIR ice9.h)
 find_path(FRONTPANEL_INCLUDE_DIR okFrontPanel.h)
 
-set(LIB_SOURCES tether_api.c zip.c)
+set(LIB_SOURCES tether_api.c zip.c logger.c)
 add_library(LIB_OBJECTS OBJECT ${LIB_SOURCES})
 set_target_properties(LIB_OBJECTS PROPERTIES POSITION_INDEPENDENT_CODE 1)
 target_compile_options(LIB_OBJECTS PRIVATE -Wall -Werror -Wno-unknown-pragmas)

--- a/logger.c
+++ b/logger.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <pthread.h>
+
+#include "logger.h"
+#include "ice9.h"
+
+static pthread_mutex_t s_log_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static void tether_log_info(const char *format, ...) {
+    char buf[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    buf[sizeof(buf)-1] = '\0';
+
+    pthread_mutex_lock(&s_log_lock);
+    printf("%s", buf);
+    pthread_mutex_unlock(&s_log_lock);
+}
+
+static void tether_log_error(const char *file, int line, const char *format, ...) {
+    char buf[256];
+    const int nwritten = snprintf(buf, sizeof(buf), "%s:%d ", file, line);
+    if (nwritten < sizeof(buf)-1) {
+        va_list args;
+        va_start(args, format);
+        vfprintf(stderr, format, args);
+        vsnprintf(buf, sizeof(buf)-nwritten, format, args);
+        va_end(args);
+    }
+    buf[sizeof(buf)-1] = '\0';
+
+    pthread_mutex_lock(&s_log_lock);
+    fprintf(stderr, "%s", buf);
+    pthread_mutex_unlock(&s_log_lock);
+}
+
+void (*tether_info_logger)(const char *format, ...) = tether_log_info;
+void (*tether_error_logger)(const char *file, int line, const char *format, ...) = tether_log_error;
+
+void tether_set_info_logger(void (*log_info)(const char *format, ...)) {
+    pthread_mutex_lock(&s_log_lock);
+    tether_info_logger = log_info;
+    pthread_mutex_unlock(&s_log_lock);
+    ice9_set_info_logger(log_info);
+}
+
+void tether_set_error_logger(void (*log_error)(const char *file, int line, const char *format, ...)) {
+    pthread_mutex_lock(&s_log_lock);
+    tether_error_logger = log_error;
+    pthread_mutex_unlock(&s_log_lock);
+    ice9_set_error_logger(log_error);
+}

--- a/logger.h
+++ b/logger.h
@@ -1,0 +1,25 @@
+#ifndef _TETHER_LOGGER_H_
+#define _TETHER_LOGGER_H_
+
+#ifdef __cplusplus
+#define EXTERN_C extern "C"
+#else  // ! __cplusplus
+#define EXTERN_C
+#endif  // __cplusplus
+
+#include <unistd.h>
+
+extern void (*tether_info_logger)(const char *format, ...);
+extern void (*tether_error_logger)(const char *file, int line, const char *format, ...);
+
+#define LOG_INFO(fmt, ...)                                        \
+    do {                                                          \
+        tether_info_logger(fmt, ##__VA_ARGS__); \
+    } while (0);
+
+#define LOG_ERROR(fmt, ...)                                        \
+    do {                                                           \
+        tether_error_logger(__FILE__, __LINE__, fmt, ##__VA_ARGS__); \
+    } while (0);
+
+#endif  // _TETHER_LOGGER_H_

--- a/tether_api.c
+++ b/tether_api.c
@@ -5,6 +5,7 @@
 //
 
 #include "tether_api.h"
+#include "logger.h"
 #include <unistd.h>
 #include <assert.h>
 #include <stdlib.h>
@@ -67,12 +68,12 @@ struct tether_handle * tether_handle_new() {
     hnd->is_valid = 1;
     if (okFrontPanel_GetDeviceCount(hnd->ok) == 0) {
         // No OpalKelly devices... assume ice9
-        fprintf(stderr, "No opal kelly devices found.. Assuming ice9\n");
+        LOG_INFO("No opal kelly devices found.. Assuming ice9\n");
         okFrontPanel_Destruct(hnd->ok);
         hnd->is_ice9 = 1;
         hnd->ice9 = ice9_new();
     } else {
-        fprintf(stderr, "Found an opal kelly device.  Assuming this is an OK setup\n");
+        LOG_INFO("Found an opal kelly device.  Assuming this is an OK setup\n");
     }
     return hnd;
 }
@@ -168,10 +169,10 @@ enum TetherError tether_load_firmware(struct tether_handle *hnd, const char * fi
     if (!fname) {
         return Tether_InvalidParameter;
     }
-    printf("Selected firmware %s\n", fname);
+    LOG_INFO("Selected firmware %s\n", fname);
     zip_entry_open(zip, fname);
     zip_entry_read(zip, &buf, &bufsize);
-    printf("Read firmware buffer of size %zu\n", bufsize);
+    LOG_INFO("Read firmware buffer of size %zu\n", bufsize);
     zip_entry_close(zip);
     if (hnd->is_ice9) {
         ice9_flash_fpga_mem(buf, bufsize);

--- a/tether_api.h
+++ b/tether_api.h
@@ -40,6 +40,10 @@ EXTERN_C enum TetherError tether_initialize_firmware(struct tether_handle *hnd);
 
 EXTERN_C uint32_t get_firmware_base_clock_frequency(struct tether_handle *hnd);
 
+EXTERN_C void tether_set_info_logger(void (*log_info)(const char *format, ...));
+
+EXTERN_C void tether_set_error_logger(void (*log_error)(const char *file, int line, const char *format, ...));
+
 /*
  * Reset the firmware - this is required as the first step
  * after the firmware is loaded.  It forces the Memory interface


### PR DESCRIPTION
By default LOG_INFO/LOG_ERROR log to standard output and standard error, respectively, but the logging functions can be set to another implementation by library users.